### PR TITLE
Rfc7405

### DIFF
--- a/lib/abnf_parsec/generator.ex
+++ b/lib/abnf_parsec/generator.ex
@@ -148,12 +148,24 @@ defmodule AbnfParsec.Generator do
   end
 
   defp expand(string) when is_binary(string) do
-    expand({:case_insensitive, string})
+    #    TODO switch this over to :case_sensitive
+    expand({:case_sensitive, string})
   end
 
   defp expand({:case_insensitive, string}) when is_binary(string) do
+    lower = String.downcase(string)
+    upper = String.upcase(string)
+
+    insensitive =
+      Enum.zip(String.to_charlist(lower), String.to_charlist(upper))
+      |> Enum.map(fn
+        {c, c} -> {:case_sensitive, <<c>>}
+        {l, u} -> {:alternation, [{:case_sensitive, <<l>>}, {:case_sensitive, <<u>>}]}
+      end)
+
     quote do
-      string(unquote(string))
+      unquote(expand({:concatenation, insensitive}))
+      |> reduce({Enum, :join, []})
     end
   end
 

--- a/lib/abnf_parsec/generator.ex
+++ b/lib/abnf_parsec/generator.ex
@@ -148,6 +148,10 @@ defmodule AbnfParsec.Generator do
   end
 
   defp expand(string) when is_binary(string) do
+    expand({:case_insensitive, string})
+  end
+
+  defp expand({:case_insensitive, string}) when is_binary(string) do
     quote do
       string(unquote(string))
     end

--- a/lib/abnf_parsec/generator.ex
+++ b/lib/abnf_parsec/generator.ex
@@ -153,6 +153,12 @@ defmodule AbnfParsec.Generator do
     end
   end
 
+  defp expand({:case_sensitive, string}) when is_binary(string) do
+    quote do
+      string(unquote(string))
+    end
+  end
+
   defp expand({:num_literal, [{:base, base}, num]}) do
     num = base_num(num, base)
 

--- a/test/abnf_parsec/rfc7405_test.exs
+++ b/test/abnf_parsec/rfc7405_test.exs
@@ -12,5 +12,10 @@ defmodule AbnfParsec.RFC7405Test do
 
     abc = "abc"
     assert {:ok, [case_sensitive: [^abc]], "", %{}, {1, 0}, 3} = RFC7405.case_sensitive(abc)
+
+    assert {:ok, [case_insensitive: ["aBc"]], "D", %{}, {1, 0}, 3} =
+             RFC7405.case_insensitive("aBcD")
+
+    assert {:error, _msg, "DBCA", %{}, {1, 0}, 0} = RFC7405.case_insensitive("DBCA")
   end
 end

--- a/test/abnf_parsec/rfc7405_test.exs
+++ b/test/abnf_parsec/rfc7405_test.exs
@@ -1,0 +1,15 @@
+defmodule AbnfParsec.RFC7405Test do
+  use ExUnit.Case, async: true
+
+  test "rfc7405" do
+    defmodule RFC7405 do
+      use AbnfParsec,
+        abnf: """
+        case-sensitive = %s"abc"
+        """
+    end
+
+    abc = "abc"
+    assert {:ok, [case_sensitive: [^abc]], "", %{}, {1, 0}, 3} = RFC7405.case_sensitive(abc)
+  end
+end

--- a/test/abnf_parsec/rfc7405_test.exs
+++ b/test/abnf_parsec/rfc7405_test.exs
@@ -6,6 +6,7 @@ defmodule AbnfParsec.RFC7405Test do
       use AbnfParsec,
         abnf: """
         case-sensitive = %s"abc"
+        case-insensitive = %i"abc"
         """
     end
 


### PR DESCRIPTION
I mean to add RFC7405 compliance and got there halfway as this patch adds support for explicit %s"..." and %i"..." rules.

However non-explicit ABNF definitions of string literals should also be equivalent to %i"..." by default, at this moment they are not because it breaks some of the test cases which assume case-sensitivity by default. 